### PR TITLE
Fix tests and add ability to change baseURL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/completions_test.go
+++ b/completions_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	completionModel = "text-davinci-003"
+	completionModel = "gpt-3.5-turbo-instruct"
 )
 
 func TestCompletions(t *testing.T) {

--- a/http.go
+++ b/http.go
@@ -169,8 +169,11 @@ func (c *Client) do(method, endpoint string, params map[string]any) (response []
 	if params == nil {
 		params = map[string]any{}
 	}
-
-	apiURL := fmt.Sprintf("%s/%s", baseURL, endpoint)
+	url := baseURL
+	if c.baseURL != nil {
+		url = *c.baseURL
+	}
+	apiURL := fmt.Sprintf("%s/%s", url, endpoint)
 
 	var req *http.Request
 	if req, err = http.NewRequest(method, apiURL, nil); err == nil {
@@ -236,7 +239,11 @@ func (c *Client) post(endpoint string, params map[string]any) (response []byte, 
 		params = map[string]any{}
 	}
 
-	apiURL := fmt.Sprintf("%s/%s", baseURL, endpoint)
+	url := baseURL
+	if c.baseURL != nil {
+		url = *c.baseURL
+	}
+	apiURL := fmt.Sprintf("%s/%s", url, endpoint)
 
 	var req *http.Request
 
@@ -331,7 +338,11 @@ func (c *Client) postCB(endpoint string, params map[string]any, cb callback) (re
 	if params == nil {
 		params = map[string]any{}
 	}
-	apiURL := fmt.Sprintf("%s/%s", baseURL, endpoint)
+	url := baseURL
+	if c.baseURL != nil {
+		url = *c.baseURL
+	}
+	apiURL := fmt.Sprintf("%s/%s", url, endpoint)
 
 	var req *http.Request
 	// application/json

--- a/http.go
+++ b/http.go
@@ -125,8 +125,8 @@ func stream(res *http.Response, cb callback) {
 					fn.Function.Arguments = fn.Function.Arguments + toolCall.Function.Arguments
 				}
 			}
-
-			if entry.Choices[0].FinishReason == "tool_calls" {
+			if entry.Choices[0].FinishReason == "tool_calls" ||
+				(entry.Choices[0].FinishReason == "stop" && fn.ID != "") {
 				// append last function call
 				toolCalls = append(toolCalls, fn)
 				entry.Choices[0].Message.ToolCalls = toolCalls

--- a/openai.go
+++ b/openai.go
@@ -24,6 +24,7 @@ type Client struct {
 	httpClient *http.Client
 
 	beta *string
+	baseURL *string
 
 	Verbose bool
 }
@@ -53,6 +54,16 @@ func NewClient(apiKey, organizationID string) *Client {
 // SetBetaHeader sets the beta HTTP header for beta features.
 func (c *Client) SetBetaHeader(beta string) *Client {
 	c.beta = &beta
+
+	return c
+}
+
+func (c *Client) SetBaseURL(baseURL string) *Client {
+	if len(baseURL) == 0 {
+		c.baseURL = nil
+	} else {
+		c.baseURL = &baseURL
+	}
 
 	return c
 }


### PR DESCRIPTION
Changing baseURL allows to use local models through the OpenAI API abstraction e.g. with ollama.

Two more tests left broken:
- Assistants file upload
- Finetuning  job creation

I am not using this functionality and I am not familiar with it.

```
--- FAIL: TestFineTuning (1.95s)
    finetuning_test.go:28: failed to create fine-tuning job: {"message":"","type":""}
```

```
2024/04/15 11:33:41 API response for v1/files: '{
  "object": "file",
  "id": "file-XM75AWpfgaRwKuMDfEX8CShu",
  "purpose": "assistants",
  "filename": "file.plain",
  "bytes": 51,
  "created_at": 1713148421,
  "status": "processed",
  "status_details": null
}


--- FAIL: TestAssistants (3.72s)
    assistants_test.go:83: failed to create assistant file: http status 400: {"code":"unsupported_file","message":"Files with extensions [.plain] are not supported for retrieval. See https://platform.openai.com/docs/assistants/tools/supported-files","type":"invalid_request_error"}
```